### PR TITLE
Good-Turing Smoothing 

### DIFF
--- a/src/TextMining.jl
+++ b/src/TextMining.jl
@@ -26,8 +26,8 @@ export  #types
   random_init, max_min_init, kmeans, elbow_method,
   #data set
   #distribution
-  probability, features, entropy, info_gain, perplexity, set_smooth,
-  remove_smoothing!, delta_smoothing!,
+  probability, features, entropy, info_gain, perplexity,
+  remove_smoothing!, delta_smoothing!, goodturing_smoothing!
   #feature vector
   sanitize!, freq_list, find_common_type, add!, subtract!, 
   multiply!, divide!, rationalize!, dist_cos, dist_zero,

--- a/src/TextMining.jl
+++ b/src/TextMining.jl
@@ -27,7 +27,7 @@ export  #types
   #data set
   #distribution
   probability, features, entropy, info_gain, perplexity,
-  remove_smoothing!, delta_smoothing!, goodturing_smoothing!
+  remove_smoothing!, delta_smoothing!, goodturing_smoothing!,
   #feature vector
   sanitize!, freq_list, find_common_type, add!, subtract!, 
   multiply!, divide!, rationalize!, dist_cos, dist_zero,

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -106,9 +106,9 @@ function _δ_smoothing(d::Distribution, key, data::Array)
   return (d.space[key]+data[1])/(data[1]*(data[2]+1)+data[3])
 end
 
-#=simple good-turing smoothing
+#simple good-turing smoothing
 function goodturing_smoothing!(d::Distribution{FeatureVector})
-  freqs = Dict{Integer,Integer}() #frequency => num keys appearing with that frequency
+  freqs = FeatureVector() 
   for value in values(d.space)
     freqs[value] += 1
   end
@@ -116,19 +116,27 @@ function goodturing_smoothing!(d::Distribution{FeatureVector})
 end
 
 function goodturing_smoothing!(d::Distribution)
-  freqs = Dict{Integer,Integer}() #frequency => num keys appearing with that frequency
+  freqs = FeatureVector() 
   for value in values(d.space.vector_sum)
     freqs[value] += 1
   end
   set_smooth!(d,_gt_smoothing, [d.total, freqs])
 end
 
-function _gt_smoothing(d::Distribution, key, data::Array)
+function _gt_smoothing(d::Distribution{FeatureVector}, key, data::Array)
   if !haskey(d.space, key)
     return data[2][1] / data[1] #num of keys that occur once / total number of keys
   end
   c = d.space[key]
-  return (c+1) * (data[2][c+1]/data[2][c])
+  c_adjust = (c+1) * (data[2][c+1]/data[2][c])
+  return c_adjust / data[1]
+end
 
-  #return distribution smoothed by good-turing, see papers
-=#
+function _gt_smoothing(d::Distribution, key, data::Array)
+  if !haskey(d.space.vector_sum, key)
+    return data[2][1] / data[1] #num of keys that occur once / total number of keys
+  end
+  c = d.space.vector_sum[key]
+  c_adjust = (c+1) * (data[2][c+1]/data[2][c])
+  return c_adjust / data[1]
+end

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -112,5 +112,8 @@ function _gt_smoothing(d::Distribution, key, data::Array)
   if !haskey(d.space, key)
     return data[2][1] / data[1] #num of keys that occur once / total number of keys
   end
+  c = d.space[key]
+  return (c+1) * (data[2][c+1]/data[2][c])
+
   #return distribution smoothed by good-turing, see papers
 =#

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -60,7 +60,7 @@ function _no_smoothing(d::Distribution, key, data::Array)
   return d.space[key] / d.total
 end
 
-#add-delta smoothing, default to add-one smoothing
+#add-delta smoothing, defaults to add-one smoothing
 function delta_smoothing!(d::Distribution, δ::Number=1)
   if δ <= 0
     Base.warn("δ must be greater than 0") 
@@ -75,3 +75,17 @@ function _δ_smoothing(d::Distribution, key, data::Array)
   end
   return (d.space[key]+data[1])/(data[1]*(data[2]+1)+data[3])
 end
+
+#=simple good-turing smoothing
+function goodturing_smoothing!(d::Distribution)
+	#need frequencies of frequencies here
+	#aka there are 120 words that occur 1 time, 20 words that occur 2 times, etc
+	set_smooth!(d,_gt_smoothing, [d.total, #frequencies])
+end
+
+function _gt_smoothing(d::Distribution, key, data::Array)
+	if !haskey(d.space, key)
+		#return "number of words that occur once" / data[1]
+	end
+	#return distribution smoothed by good-turing, see papers
+=#

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -61,6 +61,7 @@ function perplexity(d::Distribution)
   return 2^entropy(d)
 end
 
+#helper function that sets the smoothing type
 function set_smooth!(d::Distribution{FeatureVector}, f::Function, sd::Array)
   d.smooth = f
   d.smooth_data = sd
@@ -100,15 +101,16 @@ end
 
 #=simple good-turing smoothing
 function goodturing_smoothing!(d::Distribution{FeatureVector})
-  frequencies = [0, 0] 
-  for key in freq_list(d.space, (a,b) -> a[2]<b[2])
-  #aka there are 120 words that occur 1 time, 20 words that occur 2 times, etc
-  set_smooth!(d,_gt_smoothing, [d.total, #frequencies])
+  freqs = Dict{Integer,Integer}() #frequency => num keys appearing with that frequency
+  for value in values(d.space)
+    freqs[value] += 1
+  end
+  set_smooth!(d,_gt_smoothing, [d.total, freqs])
 end
 
 function _gt_smoothing(d::Distribution, key, data::Array)
   if !haskey(d.space, key)
-  #return "number of words that occur once" / data[1]
+    return data[2][1] / data[1] #num of keys that occur once / total number of keys
   end
   #return distribution smoothed by good-turing, see papers
 =#

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -78,14 +78,14 @@ end
 
 #=simple good-turing smoothing
 function goodturing_smoothing!(d::Distribution)
-	#need frequencies of frequencies here
-	#aka there are 120 words that occur 1 time, 20 words that occur 2 times, etc
-	set_smooth!(d,_gt_smoothing, [d.total, #frequencies])
+  #need frequencies of frequencies here
+  #aka there are 120 words that occur 1 time, 20 words that occur 2 times, etc
+  set_smooth!(d,_gt_smoothing, [d.total, #frequencies])
 end
 
 function _gt_smoothing(d::Distribution, key, data::Array)
-	if !haskey(d.space, key)
-		#return "number of words that occur once" / data[1]
-	end
-	#return distribution smoothed by good-turing, see papers
+  if !haskey(d.space, key)
+  #return "number of words that occur once" / data[1]
+  end
+  #return distribution smoothed by good-turing, see papers
 =#

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -71,6 +71,10 @@ function remove_smoothing!(d::Distribution)
   set_smooth!(d,_no_smoothing,[])
 end
 
+function _no_smoothing(d::Distribution{FeatureVector}, key, data::Array)
+  return d.space[key] / d.total
+end
+
 function _no_smoothing(d::Distribution, feature, data::Array)
   return d.space.vector_sum[feature] / d.total
 end
@@ -95,8 +99,9 @@ function display(dist::Distribution)
 end
 
 #=simple good-turing smoothing
-function goodturing_smoothing!(d::Distribution)
-  #need frequencies of frequencies here
+function goodturing_smoothing!(d::Distribution{FeatureVector})
+  frequencies = [0, 0] 
+  for key in freq_list(d.space, (a,b) -> a[2]<b[2])
   #aka there are 120 words that occur 1 time, 20 words that occur 2 times, etc
   set_smooth!(d,_gt_smoothing, [d.total, #frequencies])
 end

--- a/test/distribution_tests.jl
+++ b/test/distribution_tests.jl
@@ -134,7 +134,7 @@ facts("Smoothing FeatureVector has correct probabilties before and after") do
   @fact probability(d1,"unk") => (1/(3+20))
 
   #good-turing smoothing
-#=  dict3 = ["the" => 15, "of" => 16, "what" => 1, "a" => 1, "unique" => 1, "word" => 1, "twice" => 2, "two" => 2, "party" => 2, "three" => 3]
+  dict3 = ["the" => 15, "of" => 16, "what" => 1, "a" => 1, "unique" => 1, "word" => 1, "twice" => 2, "two" => 2, "party" => 2, "three" => 3]
   fv3 = FeatureVector(dict3)
   d3 = Distribution(fv3)
   goodturing_smoothing!(d3)
@@ -142,7 +142,7 @@ facts("Smoothing FeatureVector has correct probabilties before and after") do
   @fact probability(d3,"twice") => (((2+1)*(1/3))/44)
   @fact probability(d3,"three") => (((3+1)*(0/1))/44)
   @fact probability(d3,"unk") => (4/44) 
-=#
+
   #removing smoothing
   remove_smoothing!(d1)
   @fact probability(d1,"word") => (7/20)

--- a/test/distribution_tests.jl
+++ b/test/distribution_tests.jl
@@ -133,6 +133,16 @@ facts("Smoothing FeatureVector has correct probabilties before and after") do
   @fact probability(d1,"another") => (14/(3+20))
   @fact probability(d1,"unk") => (1/(3+20))
 
+  #good-turing smoothing
+#=  dict3 = ["the" => 15, "of" => 16, "what" => 1, "a" => 1, "unique" => 1, "word" => 1, "twice" => 2, "two" => 2, "party" => 2, "three" => 3]
+  fv3 = FeatureVector(dict3)
+  d3 = Distribution(fv3)
+  goodturing_smoothing!(d3)
+  @fact probability(d3,"word") => (((1+1)*(3/4))/44)
+  @fact probability(d3,"twice") => (((2+1)*(1/3))/44)
+  @fact probability(d3,"three") => (((3+1)*(0/1))/44)
+  @fact probability(d3,"unk") => (4/44) 
+=#
   #removing smoothing
   remove_smoothing!(d1)
   @fact probability(d1,"word") => (7/20)


### PR DESCRIPTION
highly frequent words might have their probability adjusted to zero if theres no other words with +1 higher frequncy 

that issue can be overcome by fitting the frequency of frequencies to a log-log line

test work when copied and pasted into julia, not when ran using using TextMining reload("runtests.jl")
